### PR TITLE
Add Jest tests for TicTacToe

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,5 @@
 # aroonsekar.github.io
+
+## Testing
+
+Run `npm test` to execute the Jest test suite.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "aroonsekar.github.io",
+  "version": "1.0.0",
+  "description": "",
+  "main": "script.js",
+  "scripts": {
+    "test": "jest"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "devDependencies": {
+    "jest": "^29.6.1"
+  },
+  "jest": {
+    "testEnvironment": "jsdom"
+  }
+}

--- a/script.js
+++ b/script.js
@@ -348,3 +348,4 @@ timelineHeadings.forEach(heading => {
         details.classList.toggle('active');
     });
 });
+if (typeof module !== 'undefined') { module.exports = { checkWin, minimax, cells }; }

--- a/tests/tic-tac-toe.test.js
+++ b/tests/tic-tac-toe.test.js
@@ -1,0 +1,48 @@
+const { JSDOM } = require('jsdom');
+
+describe('TicTacToe AI', () => {
+  let checkWin, minimax, cells;
+
+  beforeEach(() => {
+    const dom = new JSDOM(`<!DOCTYPE html><div id="board"></div><div id="message"></div><button id="play-again"></button>`);
+    global.document = dom.window.document;
+    global.window = dom.window;
+
+    // Load script after DOM is set up
+    ({ checkWin, minimax, cells } = require('../script.js'));
+  });
+
+  afterEach(() => {
+    // Reset module cache
+    jest.resetModules();
+  });
+
+  test('checkWin detects horizontal win', () => {
+    cells[0].innerHTML = 'X';
+    cells[1].innerHTML = 'X';
+    cells[2].innerHTML = 'X';
+    expect(checkWin('X')).toBe(true);
+  });
+
+  test('minimax chooses winning move for O', () => {
+    // Set up a board where O can win by playing index 2
+    cells[0].innerHTML = 'O';
+    cells[1].innerHTML = 'O';
+    // remaining cells empty
+
+    let bestScore = -Infinity;
+    let bestMove;
+    for (let i = 0; i < cells.length; i++) {
+      if (cells[i].innerHTML === '') {
+        cells[i].innerHTML = 'O';
+        const score = minimax(cells, 0, false);
+        cells[i].innerHTML = '';
+        if (score > bestScore) {
+          bestScore = score;
+          bestMove = i;
+        }
+      }
+    }
+    expect(bestMove).toBe(2);
+  });
+});


### PR DESCRIPTION
## Summary
- initialize `package.json` and configure Jest
- export Tic-Tac-Toe helpers from `script.js`
- add Jest test suite for `checkWin` and `minimax`
- document how to run the tests

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68479ded4e4c832091ac8bf4d0eec171